### PR TITLE
Accessibility: Make definition element a live region

### DIFF
--- a/src/components/form.jsx
+++ b/src/components/form.jsx
@@ -51,7 +51,7 @@ const Form = () => {
                    </form>
 
                     {error && <div className="text-purple text-sm mt-2">Oopsie. Some error occured :(</div>}
-                    {data && <div className="mt-2 text-purple font-bold text-xl ml-2"><p>{data[`${userInput}`]?.definition }</p></div>}
+                    {data && <div className="mt-2 text-purple font-bold text-xl ml-2"><p role="region" aria-live="assertive">{data[`${userInput}`]?.definition }</p></div>}
                     {data && <div className="mt-2 text-purple font-bold text-xs ml-2"><p>{ data[`${userInput}`]?.alternatives }</p></div>}
                     
 


### PR DESCRIPTION
## Changes proposed
 
A small accessibility enhancement 🙂

* Uses `role="region" aria-live="assertive"` to turn the element which displays the definition of a word into a live region. This way a screen reader will announce the definition whenever the element changes its content.

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done
[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [X] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] This PR does not contain plagiarized content.
- [X] The title of my pull request is a short description of the requested changes.

## Screenshots

![](https://user-images.githubusercontent.com/478770/193534456-4a39eb7e-f608-4591-873d-45ad55c931f5.png)

## Note to reviewers

<!-- Add notes to reviewers if applicable -->