### PR TITLE
Fixed inline-padding on mobile devices (Closes #58)

### DIFF
--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -1,11 +1,11 @@
 const Footer = () => {
-        return(
-            <footer>
-                <div className="bottom-0 text-center p-2 bg-dark">
-                    <p className="text-ash">Made with 💜 by Emy 🦄⛅ and the community :)</p>
-                </div>
-            </footer>
-        );
-}
- 
+  return (
+    <footer>
+      <div className="bottom-0 text-center p-2 bg-dark">
+        <p className="text-ash">Made with 💜 by Emy 🦄⛅ and the community &#128522;</p>
+      </div>
+    </footer>
+  );
+};
+
 export default Footer;

--- a/src/components/form.jsx
+++ b/src/components/form.jsx
@@ -1,84 +1,136 @@
 import { useEffect } from "react";
 import { useState } from "react";
 const Form = () => {
-  
-    const [data, setData] = useState(null);
-    const [error, setError] = useState(false);
-    const [errorMessage, setErrorMessage] = useState(false);
-    const [userInput, setUserInput] = useState('');
-    
-    const fetchData = (e) => {
-        e.preventDefault();
-        const url = '/server/db.json';
-        fetch(`${url}`)
-        .then(response => {
-            if(!response.ok){
-                throw Error('Resource not found.');
-            }
-            return response.json();
-        })
-        .then((data) => {
-            if (!(userInput in data)) { 
-                setErrorMessage(true);
-            } else {
-                setData(data);
-                setError(false);
-                setErrorMessage(false);
-            }
-        })
-        .catch(err => {
-            console.log(err.message);
-            setError(true);
-        });
-    }
+  const [data, setData] = useState(null);
+  const [error, setError] = useState(false);
+  const [errorMessage, setErrorMessage] = useState(false);
+  const [userInput, setUserInput] = useState("");
 
-    useEffect(()=>{
-        setErrorMessage('');
-    }, [userInput]);
+  const fetchData = (e) => {
+    e.preventDefault();
+    const url = "/server/db.json";
+    fetch(`${url}`)
+      .then((response) => {
+        if (!response.ok) {
+          throw Error("Resource not found.");
+        }
+        return response.json();
+      })
+      .then((data) => {
+        if (!(userInput in data)) {
+          setErrorMessage(true);
+        } else {
+          setData(data);
+          setError(false);
+          setErrorMessage(false);
+        }
+      })
+      .catch((err) => {
+        console.log(err.message);
+        setError(true);
+      });
+  };
 
-    return(
-        <div className="bg-dark py-12 px-14" >
-            <section className="block justify-center pb-16 md:flex">
-                <div className='md:w-1/2 md:pr-20 md:text-left text-center'>
-                    <h2 className='text-purple font-bold text-3xl'><span className="text-ash">Start by entering a slang,</span> and our dictionary will spit out an abbreviation. </h2> 
-                    <p className="text-gray text-sm mt-5">*For now, abbreviations are one-way. For example, Idk can only translate to 'I don't know', and not the other way round.</p>
+  useEffect(() => {
+    setErrorMessage("");
+  }, [userInput]);
 
-                    <p className="text-sm mt-5 text-ash">Found something odd? <a href="https://github.com/Njong392/Abbreve"><span className="text-purple">Create a github issue.</span></a></p>     
-                </div>
+  return (
+    <div className="bg-dark py-12 px-[14px]">
+      <section className="block justify-center pb-16 md:flex">
+        <div className="md:w-1/2 md:pr-20 md:text-left text-center">
+          <h2 className="text-purple font-bold text-3xl">
+            <span className="text-ash">Start by entering a slang,</span> and our dictionary will
+            spit out an abbreviation.{" "}
+          </h2>
+          <p className="text-gray text-sm mt-5">
+            *For now, abbreviations are one-way. For example, Idk can only translate to 'I don't
+            know', and not the other way round.
+          </p>
 
-                <div>
-                   <form className="block md:flex items-center gap-3" id="form">
-                        <div className="bg-ash h-11 rounded-full flex items-center p-3">
-                            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={2.5} stroke="currentColor" className="w-6 h-6 text-purple">
-                            <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z" />
-                            </svg>
-
-                            <input type="text" placeholder="Search slang full meaning..." className="flex-1 w-1/2 h-11 rounded-full ml-2 border-none outline-none text-gray text-lg bg-ash" value={userInput} onChange={(e) => setUserInput(e.target.value.toLocaleLowerCase() )} />
-                        </div>
-
-                        <button onClick={fetchData} className="bg-purple text-ash font-bold rounded-xl hover:scale-110 p-2 mt-2 md:mt-0">Submit</button>
-                       
-                   </form>
-
-                    {data && <div className="mt-2 text-purple font-bold text-xl ml-2"><p role="region" aria-live="assertive">{data[`${userInput}`]?.definition }</p></div>}
-                    
-                    {data && <div className="mt-2 text-purple font-bold text-xs ml-2"><p>{ data[`${userInput}`]?.alternatives }</p></div>}
-
-                    {error && <div className="text-purple text-sm mt-2">Oops. Some connection error occured.</div>}
-                    
-                    {errorMessage && <div className="mt-4">
-                        <p className="text-purple">This entry does not exist in our records as of yet :(</p>
-                        <p className="text-ash mt-2">1. You can help us add this by creating a <a href="https://github.com/Njong392/Abbreve" className="text-ash text-purple">github issue</a></p>
-                        <p className="text-ash">2. Or, you could fill out this <a href="https://t.co/mp86BLYBhq" className="text-purple">feedback form</a> and we will address the issue</p>
-                        
-                    </div>}
-
-                </div>
-              
-            </section>
-
+          <p className="text-sm mt-5 text-ash">
+            Found something odd?{" "}
+            <a href="https://github.com/Njong392/Abbreve">
+              <span className="text-purple">Create a github issue.</span>
+            </a>
+          </p>
         </div>
-    )
-}
+
+        <div>
+          <form className="block md:flex items-center gap-3" id="form">
+            <div className="bg-ash h-11 rounded-full flex items-center p-3">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={2.5}
+                stroke="currentColor"
+                className="w-6 h-6 text-purple"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
+                />
+              </svg>
+
+              <input
+                type="text"
+                placeholder="Search slang full meaning..."
+                className="flex-1 w-1/2 h-11 rounded-full ml-2 border-none outline-none text-gray text-lg bg-ash"
+                value={userInput}
+                onChange={(e) => setUserInput(e.target.value.toLocaleLowerCase())}
+              />
+            </div>
+
+            <button
+              onClick={fetchData}
+              className="bg-purple text-ash font-bold rounded-xl hover:scale-110 p-2 mt-2 md:mt-0"
+            >
+              Submit
+            </button>
+          </form>
+
+          {data && (
+            <div className="mt-2 text-purple font-bold text-xl ml-2">
+              <p role="region" aria-live="assertive">
+                {data[`${userInput}`]?.definition}
+              </p>
+            </div>
+          )}
+
+          {data && (
+            <div className="mt-2 text-purple font-bold text-xs ml-2">
+              <p>{data[`${userInput}`]?.alternatives}</p>
+            </div>
+          )}
+
+          {error && (
+            <div className="text-purple text-sm mt-2">Oops. Some connection error occured.</div>
+          )}
+
+          {errorMessage && (
+            <div className="mt-4">
+              <p className="text-purple">This entry does not exist in our records as of yet :(</p>
+              <p className="text-ash mt-2">
+                1. You can help us add this by creating a{" "}
+                <a href="https://github.com/Njong392/Abbreve" className="text-ash text-purple">
+                  github issue
+                </a>
+              </p>
+              <p className="text-ash">
+                2. Or, you could fill out this{" "}
+                <a href="https://t.co/mp86BLYBhq" className="text-purple">
+                  feedback form
+                </a>{" "}
+                and we will address the issue
+              </p>
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+};
 
 export default Form;

--- a/src/components/hero.jsx
+++ b/src/components/hero.jsx
@@ -1,119 +1,144 @@
-import btw from '../assets/btw.png';
-import fyi from '../assets/fyi.png';
-import idk from '../assets/idk.png';
-import ig from '../assets/ig.png';
-import lfg from '../assets/lfg.png';
-import nate from '../assets/nate.jpg';
-import emy from '../assets/emy.jpg';
-import {Link} from 'react-scroll';
+import btw from "../assets/btw.png";
+import fyi from "../assets/fyi.png";
+import idk from "../assets/idk.png";
+import ig from "../assets/ig.png";
+import lfg from "../assets/lfg.png";
+import nate from "../assets/nate.jpg";
+import emy from "../assets/emy.jpg";
+import { Link } from "react-scroll";
 
 const Hero = () => {
-    return ( 
-        <main className="bg-dark md:px-40 py-12 px-14">
-            <header className="text-center md:text-2xl relative mt-12">
-                <h1 className="text-purple font-bold">Writing on the internet</h1>
-                <h1 className="text-ash font-bold mt-2">is changing. IYKYK</h1>
+  return (
+    <main className="bg-dark md:px-40 py-12 px-[24px]">
+      <header className="text-center md:text-2xl relative mt-12">
+        <h1 className="text-purple font-bold">Writing on the internet</h1>
+        <h1 className="text-ash font-bold mt-2">is changing. IYKYK</h1>
 
-                <div className="absolute right-14 bottom-20 lg:visible invisible">
-                    <div className="w-24 h-4 bg-purple relative -rotate-6">
-                        <div className="absolute top-[3px]">
-                            <p className="text-ash text-sm font-semibold">If You Know,</p>
-                        </div>
-                    </div>
-                </div>
-                <div className="absolute right-12 bottom-14 lg:visible invisible">
-                    <div className="right-8 w-20 h-4 bg-purple relative -rotate-6">
-                        <div className="absolute top-[3px]">
-                            <p className="text-ash text-sm font-semibold">You Know.</p>
-                        </div>
-                    </div>
-                </div>
-
-                <Link to="form" smooth={true} duration={500} spy={false} className='bg-purple text-ash font-bold rounded-xl hover:scale-110 mt-5 md:invisible visible mt-5 p-2'>Find an abbreve(tion)</Link>
-                    
-                
-            </header>
-
-            <div className='flex flex-wrap justify-center animate-breeze invisible md:visible'>
-                <img src={btw} alt="" className='rotate-2 h-[20%] w-[20%]'/>
-                <img src={fyi} alt="" className='-rotate-3 h-[20%] w-[20%]'/>
-                <img src={idk} alt="" className='rotate-3 h-[20%] w-[20%]'/>
-                <img src={ig} alt="" className='rotate-6 h-[20%] w-[20%]'/>
-                <img src={lfg} alt="" className='-rotate-6 h-[20%] w-[20%]'/>    
+        <div className="absolute right-14 bottom-20 lg:visible invisible">
+          <div className="w-24 h-4 bg-purple relative -rotate-6">
+            <div className="absolute top-[3px]">
+              <p className="text-ash text-sm font-semibold">If You Know,</p>
             </div>
+          </div>
+        </div>
+        <div className="absolute right-12 bottom-14 lg:visible invisible">
+          <div className="right-8 w-20 h-4 bg-purple relative -rotate-6">
+            <div className="absolute top-[3px]">
+              <p className="text-ash text-sm font-semibold">You Know.</p>
+            </div>
+          </div>
+        </div>
 
-            <section className='block justify-center gap-10 mt-20 items-center md:flex'>
-                <div className='md:w-1/2 md:pr-20 md:text-left text-center'>
-                    <p className='text-purple font-bold text-3xl'><span className='text-ash'>Abbreve (A-bree-vay)</span> is an open source dictionary for <span className='text-ash'>slangs.</span> </p> 
-                    <p className='text-purple font-bold text-3xl mt-2'>Curated by the community, for the community.</p>   
-                    
-                </div>
+        <Link
+          to="form"
+          smooth={true}
+          duration={500}
+          spy={false}
+          className="bg-purple text-ash font-bold rounded-xl hover:scale-110 mt-5 md:invisible visible p-2"
+        >
+          Find an abbreve(tion)
+        </Link>
+      </header>
 
-                <div className='border-2 p-4 rounded-lg border-purple md:rotate-3 relative md:mt-0'>
-                    <div className='flex gap-2 items-center'>
-                        <img src={nate} alt="" className='h-12 w-12 rounded-full' />
-                        <div>
-                            <a href="https://twitter.com/Nateemerson/status/1567566265719599105?s=20&t=QAOQu1feHo07evNBHFvAIQ" className='text-purple'>
-                                <p className='font-bold'>Nate (DojoJOJO)</p>
-                                <p className='text-sm'>@Nateemerson</p>
-                            </a>
-                        </div>
-                    </div>
+      <div className="flex flex-wrap justify-center animate-breeze invisible md:visible">
+        <img src={btw} alt="" className="rotate-2 h-[20%] w-[20%]" />
+        <img src={fyi} alt="" className="-rotate-3 h-[20%] w-[20%]" />
+        <img src={idk} alt="" className="rotate-3 h-[20%] w-[20%]" />
+        <img src={ig} alt="" className="rotate-6 h-[20%] w-[20%]" />
+        <img src={lfg} alt="" className="-rotate-6 h-[20%] w-[20%]" />
+      </div>
 
-                    <p className='mt-4'><span className='text-gray'>Replying to</span> <span className='text-purple'>@DunsinWebDev and @njongemy</span></p>
-                    <p className='mt-2 text-ash'>idk wtf ur on about... ICYMI IMHO RTFM, KISS, SHIT or GTFO.</p>
-                    <p className='text-sm text-gray'>18:31 . 07 Sep 22 . <span className='text-purple'> Twitter Web App</span></p>
+      <section className="block justify-center gap-10 mt-20 items-center md:flex">
+        <div className="md:w-1/2 md:pr-20 md:text-left text-center">
+          <p className="text-purple font-bold text-3xl">
+            <span className="text-ash">Abbreve (A-bree-vay)</span> is an open source dictionary for{" "}
+            <span className="text-ash">slangs.</span>{" "}
+          </p>
+          <p className="text-purple font-bold text-3xl mt-2">
+            Curated by the community, for the community.
+          </p>
+        </div>
 
-                    <div className='absolute w-32 border-2 border-purple rounded-lg p-2 -top-14 -right-4 bg-dark rotate-6 invisible lg:visible'>
-                        <p className='text-ash text-xl font-bold '>Reading shouldn't feel like work.</p>
-                        
-                    </div>
-                </div>
+        <div className="border-2 p-4 rounded-lg border-purple md:rotate-3 relative md:mt-0">
+          <div className="flex gap-2 items-center">
+            <img src={nate} alt="" className="h-12 w-12 rounded-full" />
+            <div>
+              <a
+                href="https://twitter.com/Nateemerson/status/1567566265719599105?s=20&t=QAOQu1feHo07evNBHFvAIQ"
+                className="text-purple"
+              >
+                <p className="font-bold">Nate (DojoJOJO)</p>
+                <p className="text-sm">@Nateemerson</p>
+              </a>
+            </div>
+          </div>
 
-            </section>
+          <p className="mt-4">
+            <span className="text-gray">Replying to</span>{" "}
+            <span className="text-purple">@DunsinWebDev and @njongemy</span>
+          </p>
+          <p className="mt-2 text-ash">
+            idk wtf ur on about... ICYMI IMHO RTFM, KISS, SHIT or GTFO.
+          </p>
+          <p className="text-sm text-gray">
+            18:31 . 07 Sep 22 . <span className="text-purple"> Twitter Web App</span>
+          </p>
 
+          <div className="absolute w-32 border-2 border-purple rounded-lg p-2 -top-14 -right-4 bg-dark rotate-6 invisible lg:visible">
+            <p className="text-ash text-xl font-bold ">Reading shouldn't feel like work.</p>
+          </div>
+        </div>
+      </section>
 
-            <section className='block justify-center gap-10 mt-20 items-center md:flex'>
-                <div className='border-2 p-4 rounded-lg border-purple md:rotate-3 relative md:mt-0'>
-                    <div className='flex gap-2 items-center'>
-                        <img src={emy} alt="" className='h-12 w-12 rounded-full' />
-                        <div>
-                            <a href="https://twitter.com/njong_emy/status/1567561277135781888?s=20&t=QAOQu1feHo07evNBHFvAIQ" className='text-purple'>
-                                <p className='font-bold'>Emy 🦄⛅</p>
-                                <p className='text-sm'>@njong_emy</p>
-                            </a>
-                        </div>
-                    </div>
+      <section className="block justify-center gap-10 mt-20 items-center md:flex">
+        <div className="border-2 p-4 rounded-lg border-purple md:rotate-3 relative md:mt-0">
+          <div className="flex gap-2 items-center">
+            <img src={emy} alt="" className="h-12 w-12 rounded-full" />
+            <div>
+              <a
+                href="https://twitter.com/njong_emy/status/1567561277135781888?s=20&t=QAOQu1feHo07evNBHFvAIQ"
+                className="text-purple"
+              >
+                <p className="font-bold">Emy 🦄⛅</p>
+                <p className="text-sm">@njong_emy</p>
+              </a>
+            </div>
+          </div>
 
-                    <p className='mt-5 text-ash'>Do you find yourself googling the meaning of slangs like hmu, lgtm, lfg etc ?</p>
+          <p className="mt-5 text-ash">
+            Do you find yourself googling the meaning of slangs like hmu, lgtm, lfg etc ?
+          </p>
 
-                    <div className='flex justify-between items-center mt-2'>
-                        <div className='h-8 w-3/4 bg-purple rounded-sm p-1'>
-                            <p className='text-ash'>Always 😢</p>
-                        </div>
-                        <p className='text-ash'>84.8%</p>
-                    </div>
+          <div className="flex justify-between items-center mt-2">
+            <div className="h-8 w-3/4 bg-purple rounded-sm p-1">
+              <p className="text-ash">Always 😢</p>
+            </div>
+            <p className="text-ash">84.8%</p>
+          </div>
 
-                    <div className='mt-2 flex justify-between items-center'>
-                        <div className='h-8 md:w-1/4 w-1/2 bg-purple rounded-sm p-1'>
-                            <p className='text-ash'>Never 🙂</p>
-                        </div>
-                        <p className='text-ash'>15.2%</p>
-                    </div>
+          <div className="mt-2 flex justify-between items-center">
+            <div className="h-8 md:w-1/4 w-1/2 bg-purple rounded-sm p-1">
+              <p className="text-ash">Never 🙂</p>
+            </div>
+            <p className="text-ash">15.2%</p>
+          </div>
 
-                    <p className='text-sm text-gray mt-2'>18:11 . 07 Sep 22 . <span className='text-purple'> Twitter for Android</span></p>
+          <p className="text-sm text-gray mt-2">
+            18:11 . 07 Sep 22 . <span className="text-purple"> Twitter for Android</span>
+          </p>
+        </div>
 
-                </div>
-                
-                
-                <div className='md:w-1/2 md:text-left text-center mt-5 md:mt-0'>
-                    <h2 className='text-purple font-bold text-3xl'><span className='text-ash'>Googling</span> in between conversations <span className='text-ash'>is</span> fast becoming <span className='text-ash'>the new normal.</span></h2>       
-                </div>
+        <div className="md:w-1/2 md:text-left text-center mt-5 md:mt-0">
+          <h2 className="text-purple font-bold text-3xl">
+            <span className="text-ash">Googling</span> in between conversations{" "}
+            <span className="text-ash">is</span> fast becoming{" "}
+            <span className="text-ash">the new normal.</span>
+          </h2>
+        </div>
+      </section>
+    </main>
+  );
+};
 
-            </section>
-
-        </main>
-     );
-}
- 
-export default Hero;   <div className='h-56 w-56 relative border-2 border-purple'></div>
+export default Hero;
+<div className="h-56 w-56 relative border-2 border-purple"></div>;


### PR DESCRIPTION
## Fixes Issue
Closes #58 

## Changes proposed
1. Reduce the left and right padding on mobile screens to utilize more space.
1. Changed "fake emoji" to a real one in the footer.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [x] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots
### Before
![abbreve vercel app_(Samsung Galaxy S20 Ultra)](https://user-images.githubusercontent.com/35191595/193824784-5fd2f40d-3b53-4dc2-b7fb-62e8d23c0166.png)

### After
![localhost_5173_(Samsung Galaxy S20 Ultra)](https://user-images.githubusercontent.com/35191595/193824910-9bc2c74e-25fe-418d-a749-e8d495fca438.png)


## Note to reviewers

<!-- Add notes to reviewers if applicable -->