### PR TITLE
feat: UI/UX improvements - moved search box to the top

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,5 @@
 import Hero from "./components/hero";
 import Navbar from "./components/navbar";
-import Form from "./components/form";
 import Footer from "./components/footer";
 
 const App = () => {
@@ -8,7 +7,6 @@ const App = () => {
     <div className="font-poppins">
       <Navbar />
       <Hero />
-      <Form />
       <Footer />
     </div>
   );

--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -2,7 +2,13 @@ const Footer = () => {
   return (
     <footer>
       <div className="bottom-0 text-center p-2 bg-dark">
-        <p className="text-ash">
+        <p className="text-sm mt-5 text-ash">
+          Found something odd?{" "}
+          <a href="https://github.com/Njong392/Abbreve">
+            <span className="text-purple">Create a github issue.</span>
+          </a>
+        </p>
+        <p className="mt-2 text-ash">
           Made with 💜 by Emy 🦄⛅ and the community &#128522;
         </p>
       </div>

--- a/src/components/form.jsx
+++ b/src/components/form.jsx
@@ -13,65 +13,53 @@ const Form = () => {
 
     if (userInput.trim().length === 0) {
       setIsUserInputBlank(true);
-   }
-   
-    else {
+    } else {
       fetch(`${url}`)
-      .then((response) => {
-        if (response.status === 404) {
-           setIsUserInputBlank(false);
-          setErrorMessage(true);     
-        }
-        else if(!response.ok){
-          throw Error('Resource not found');
-        }
-        return response.json();
-      })
-      .then((data) => {        
+        .then((response) => {
+          if (response.status === 404) {
+            setIsUserInputBlank(false);
+            setErrorMessage(true);
+          } else if (!response.ok) {
+            throw Error("Resource not found");
+          }
+          return response.json();
+        })
+        .then((data) => {
           setData(data);
           setError(false);
           setErrorMessage(false);
-          setIsUserInputBlank(false);      
-
-      })
-      .catch((err) => {
-        console.log(err.message);
-        setErrorMessage(true);
-        setIsUserInputBlank(false); 
-
-      })
+          setIsUserInputBlank(false);
+        })
+        .catch((err) => {
+          console.log(err.message);
+          setErrorMessage(true);
+          setIsUserInputBlank(false);
+        });
     }
   };
 
   useEffect(() => {
     setErrorMessage("");
-    setData(false)
-    setIsUserInputBlank(false)
-    setError(false)
+    setData(false);
+    setIsUserInputBlank(false);
+    setError(false);
   }, [userInput]);
 
   return (
     <div className="bg-dark py-12 px-[14px]">
-      <section className="block justify-center pb-16 md:flex">
+      <section className="block justify-center pb-16 md:flex items-center">
         <div className="md:w-1/2 md:pr-20 md:text-left text-center">
           <h2 className="text-purple font-bold text-3xl">
-            <span className="text-ash">Start by entering a slang,</span> and our dictionary will
-            spit out an abbreviation.{" "}
+            <span className="text-ash">Start by entering a slang,</span> and our
+            dictionary will spit out an abbreviation.{" "}
           </h2>
           <p className="text-gray text-sm mt-5">
-            *For now, abbreviations are one-way. For example, Idk can only translate to 'I don't
-            know', and not the other way round.
-          </p>
-
-          <p className="text-sm mt-5 text-ash">
-            Found something odd?{" "}
-            <a href="https://github.com/Njong392/Abbreve">
-              <span className="text-purple">Create a github issue.</span>
-            </a>
+            *For now, abbreviations are one-way. For example, Idk can only
+            translate to 'I don't know', and not the other way round.
           </p>
         </div>
 
-        <div>
+        <div className="mt-2 md:mt-0">
           <form className="block md:flex items-center gap-3" id="form">
             <div className="bg-ash h-11 rounded-full flex items-center p-3">
               <svg
@@ -80,28 +68,28 @@ const Form = () => {
                 viewBox="0 0 24 24"
                 strokeWidth={2.5}
                 stroke="currentColor"
-                className="w-6 h-6 text-deeppurple"
-              >
+                className="w-6 h-6 text-deeppurple">
                 <path
                   strokeLinecap="round"
                   strokeLinejoin="round"
                   d="M21 21l-5.197-5.197m0 0A7.5 7.5 0 105.196 5.196a7.5 7.5 0 0010.607 10.607z"
                 />
               </svg>
-              
+
               <input
                 type="text"
                 placeholder="Search slang full meaning..."
                 className="flex-1 w-1/2 h-11 rounded-full ml-2 border-none outline-none text-gray text-lg bg-ash"
                 value={userInput}
-                onChange={(e) => setUserInput(e.target.value.toLocaleLowerCase())}
+                onChange={(e) =>
+                  setUserInput(e.target.value.toLocaleLowerCase())
+                }
               />
             </div>
 
             <button
               onClick={fetchData}
-              className="bg-deeppurple text-ash font-bold rounded-xl hover:scale-110 p-2 mt-2 md:mt-0"
-            >
+              className="bg-deeppurple text-ash font-bold rounded-xl hover:scale-110 p-2 mt-2 md:mt-0">
               Submit
             </button>
           </form>
@@ -109,7 +97,7 @@ const Form = () => {
           {data && (
             <div className="mt-2 text-purple font-bold text-xl ml-2">
               <p role="region" aria-live="assertive">
-              {data.definition}
+                {data.definition}
               </p>
             </div>
           )}
@@ -121,11 +109,9 @@ const Form = () => {
           )}
 
           {error && (
-
             <div className="text-purple text-sm mt-2">
               Oops. Some connection error occured.
             </div>
-          
           )}
 
           {isUserInputBlank && (
@@ -134,15 +120,15 @@ const Form = () => {
                 Search bar 🔍 is Empty! Please input a slang.
               </p>
             </div>
-
           )}
 
           {errorMessage && (
             <div className="mt-4">
-              <p className="text-purple">This entry does not exist in our records as of yet :(</p>
+              <p className="text-purple">
+                This entry does not exist in our records as of yet :(
+              </p>
               <p className="text-ash mt-2">
                 1. You can help us add this by creating a{" "}
-
                 <a
                   href="https://github.com/Njong392/Abbreve"
                   className="text-ash text-purple">

--- a/src/components/form.jsx
+++ b/src/components/form.jsx
@@ -47,7 +47,7 @@ const Form = () => {
 
   return (
     <div className="bg-dark py-12 px-[14px]">
-      <section className="block justify-center pb-16 md:flex items-center">
+      <section className="block justify-center md:pb-16 md:flex items-center">
         <div className="md:w-1/2 md:pr-20 md:text-left text-center">
           <h2 className="text-purple font-bold text-3xl">
             <span className="text-ash">Start by entering a slang,</span> and our

--- a/src/components/hero.jsx
+++ b/src/components/hero.jsx
@@ -43,7 +43,7 @@ const Hero = () => {
         <Form />
       </div>
 
-      <section className="block justify-center gap-10 md:mt-20 items-center md:flex">
+      <section className="block justify-center gap-10 items-center md:flex">
         <div className="md:w-1/2 md:pr-20 md:text-left text-center">
           <p className="text-purple font-bold text-3xl">
             <span className="text-ash">Abbreve (A-bree-vay)</span> is an open

--- a/src/components/hero.jsx
+++ b/src/components/hero.jsx
@@ -11,27 +11,25 @@ import Form from "./form";
 const Hero = () => {
   return (
     <main className="bg-dark md:px-40 py-12 px-[24px]">
-      <header className="text-center relative mt-12">
-        <div className="text-4xl md:text-7xl mb-5">
+      <header className="text-center mt-12">
+        <div className="text-4xl md:text-7xl mb-5 relative">
           <h1 className="text-purple font-bold">Writing on the internet</h1>
           <h1 className="text-ash font-bold mt-2">is changing. IYKYK</h1>
-        </div>
-        <Form />
-        <div className="absolute right-14 bottom-20 lg:visible invisible">
-          <div className="w-24 h-4 bg-deeppurple relative -rotate-6">
-            <div className="absolute top-[3px]">
-              <p className="text-ash text-sm font-semibold">If You Know,</p>
+          <div className="absolute right-14 bottom-9 lg:visible invisible">
+            <div className="w-24 h-4 bg-deeppurple relative -rotate-6">
+              <div className="absolute top-[3px]">
+                <p className="text-ash text-sm font-semibold">If You Know,</p>
+              </div>
+            </div>
+          </div>
+          <div className="absolute right-12 bottom-3 lg:visible invisible">
+            <div className="right-8 w-20 h-4 bg-deeppurple relative -rotate-6">
+              <div className="absolute top-[3px]">
+                <p className="text-ash text-sm font-semibold">You Know.</p>
+              </div>
             </div>
           </div>
         </div>
-        <div className="absolute right-12 bottom-14 lg:visible invisible">
-          <div className="right-8 w-20 h-4 bg-deeppurple relative -rotate-6">
-            <div className="absolute top-[3px]">
-              <p className="text-ash text-sm font-semibold">You Know.</p>
-            </div>
-          </div>
-        </div>
-
         <Link
           to="form"
           smooth={true}
@@ -40,9 +38,10 @@ const Hero = () => {
           className="bg-purple text-ash font-bold rounded-xl hover:scale-110 md:invisible visible p-2">
           Find an abbreve(tion)
         </Link>
+        <Form />
       </header>
 
-      <div className="flex flex-wrap justify-center animate-breeze invisible md:visible">
+      <div className="hidden md:flex flex-wrap justify-center animate-breeze">
         <img src={btw} alt="btw" className="rotate-2 h-[20%] w-[20%]" />
         <img src={fyi} alt="fyi" className="-rotate-3 h-[20%] w-[20%]" />
         <img src={idk} alt="idk" className="rotate-3 h-[20%] w-[20%]" />
@@ -50,7 +49,7 @@ const Hero = () => {
         <img src={lfg} alt="lfg" className="-rotate-6 h-[20%] w-[20%]" />
       </div>
 
-      <section className="block justify-center gap-10 mt-20 items-center md:flex">
+      <section className="block justify-center gap-10 md:mt-20 items-center md:flex">
         <div className="md:w-1/2 md:pr-20 md:text-left text-center">
           <p className="text-purple font-bold text-3xl">
             <span className="text-ash">Abbreve (A-bree-vay)</span> is an open

--- a/src/components/hero.jsx
+++ b/src/components/hero.jsx
@@ -6,6 +6,7 @@ import lfg from "../assets/lfg.png";
 import nate from "../assets/nate.jpg";
 import emy from "../assets/emy.jpg";
 import { Link } from "react-scroll";
+import Form from "./form";
 
 const Hero = () => {
   return (
@@ -15,7 +16,7 @@ const Hero = () => {
           <h1 className="text-purple font-bold">Writing on the internet</h1>
           <h1 className="text-ash font-bold mt-2">is changing. IYKYK</h1>
         </div>
-
+        <Form />
         <div className="absolute right-14 bottom-20 lg:visible invisible">
           <div className="w-24 h-4 bg-deeppurple relative -rotate-6">
             <div className="absolute top-[3px]">

--- a/src/components/hero.jsx
+++ b/src/components/hero.jsx
@@ -5,7 +5,6 @@ import ig from "../assets/ig.png";
 import lfg from "../assets/lfg.png";
 import nate from "../assets/nate.jpg";
 import emy from "../assets/emy.jpg";
-import { Link } from "react-scroll";
 import Form from "./form";
 
 const Hero = () => {
@@ -30,15 +29,6 @@ const Hero = () => {
             </div>
           </div>
         </div>
-        <Link
-          to="form"
-          smooth={true}
-          duration={500}
-          spy={false}
-          className="bg-purple text-ash font-bold rounded-xl hover:scale-110 md:invisible visible p-2">
-          Find an abbreve(tion)
-        </Link>
-        <Form />
       </header>
 
       <div className="hidden md:flex flex-wrap justify-center animate-breeze">
@@ -47,6 +37,10 @@ const Hero = () => {
         <img src={idk} alt="idk" className="rotate-3 h-[20%] w-[20%]" />
         <img src={ig} alt="if" className="rotate-6 h-[20%] w-[20%]" />
         <img src={lfg} alt="lfg" className="-rotate-6 h-[20%] w-[20%]" />
+      </div>
+
+      <div className="text-center">
+        <Form />
       </div>
 
       <section className="block justify-center gap-10 md:mt-20 items-center md:flex">

--- a/src/components/hero.jsx
+++ b/src/components/hero.jsx
@@ -39,9 +39,7 @@ const Hero = () => {
         <img src={lfg} alt="lfg" className="-rotate-6 h-[20%] w-[20%]" />
       </div>
 
-      <div className="text-center">
-        <Form />
-      </div>
+      <Form />
 
       <section className="block justify-center gap-10 items-center md:flex">
         <div className="md:w-1/2 md:pr-20 md:text-left text-center">

--- a/src/components/navbar.jsx
+++ b/src/components/navbar.jsx
@@ -1,7 +1,4 @@
-
 import Logo from "../assets/logo.png";
-import { Link } from "react-scroll";
-
 
 const Navbar = () => {
   return (
@@ -28,19 +25,10 @@ const Navbar = () => {
               />
             </svg>
           </a>
-          <Link
-            to="form"
-            smooth={true}
-            duration={600}
-            className="bg-deeppurple text-ash font-bold rounded-xl p-2 hover:scale-110 outline-none hidden md:block ml-4 cursor-pointer">
-            Get Started{" "}
-          </Link>
         </div>
       </div>
     </nav>
   );
 };
-
-               
 
 export default Navbar;


### PR DESCRIPTION
Move the search input to the top so that users can easily and quickly search for abbrev definitions

Closes #86

### What new changes did you make? Tick all applicable boxes
- [ ] Added new abbreviation
- [ ] Fixed something in the source code
- [x] Added a new feature
- [ ] Fixed the docs (README.md, CONTRIBTUING.md, etc)

<!--Give a brief outline of changes you made. If you added slangs, which ones? -->
### Changes
 - Currently, users have to scroll down in order to search for abbreviations. With this change, the search form is moved to the top along with the banner. Makes it easier for users to search from a UX perspective.
 - I have kept the "Found something odd? Create a github issue." section in the footer as I felt it would be odd to have this in the hero section.
 - Fixed formatting/lint issue within form.jsx . (Taken care by VS code format on save). Functionally, the only change in this file is some additional tailwind classes to center the form and add some margin.
 
<!--Optional, but advised -->
### Share a screeshot of new changes
![image](https://user-images.githubusercontent.com/2094439/195000162-3a36a97f-08ab-4620-8c5c-320b618fdf8c.png)

Mobile
![image](https://user-images.githubusercontent.com/2094439/195000406-e80b1072-5c01-48a1-b527-c9fb48d410e6.png)

Footer
![image](https://user-images.githubusercontent.com/2094439/195003353-7bb3d9f7-bea7-4897-b9cd-029fe53cf5e3.png)
