### PR TITLE
Remove scroll library from getting started link

### DIFF
--- a/src/components/navbar.jsx
+++ b/src/components/navbar.jsx
@@ -1,7 +1,4 @@
-
 import Logo from "../assets/logo.png";
-import { Link } from "react-scroll";
-
 
 const Navbar = () => {
   return (
@@ -28,19 +25,15 @@ const Navbar = () => {
               />
             </svg>
           </a>
-          <Link
-            to="form"
-            smooth={true}
-            duration={600}
-            className="bg-deeppurple text-ash font-bold rounded-xl p-2 hover:scale-110 outline-none hidden md:block ml-4 cursor-pointer">
+          <a
+            href="#form"
+            className="bg-deeppurple text-ash font-bold rounded-xl p-2 hover:scale-110 md:block ml-4 cursor-pointer">
             Get Started{" "}
-          </Link>
+          </a>
         </div>
       </div>
     </nav>
   );
 };
-
-               
 
 export default Navbar;

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,8 @@
 @tailwind base;
+html {
+  scroll-behavior: smooth;
+}
+
 @tailwind components;
 @tailwind utilities;
 


### PR DESCRIPTION
<!--What issue does this pull request close -->

Closes #125 

### What new changes did you make? Tick all applicable boxes
- [ ] Added new abbreviation
- [x] Fixed something in the source code
- [ ] Added a new feature
- [ ] Fixed the docs (README.md, CONTRIBTUING.md, etc)

<!--Give a brief outline of changes you made. If you added slangs, which ones? -->
### Describe the new changes you added.
- Removed the Link component imported from the scroll library and used a regular anchor tag instead so that the link is now keyboard focusable
- Removed the outline-none class from the getting started link so that people using a keyboard know where their focus is
- Added a smooth-scroll to the html to replicate the scroll library.

<!--Optional, but advised -->
### Share a screeshot of new changes
Everything looks the same as before
