### PR TITLE
Update pre-commit hook to sync package-lock.json

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,13 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 npx lint-staged --concurrent false
+
+function changed {
+  git diff --name-only HEAD@{1} HEAD | grep "^$1" > /dev/null 2>&1
+}
+
+if changed "package.json"; then
+  echo "Changes detected in package.json, updating package-lock.json in progress."
+  npm i --package-lock-only
+  git add package-lock.json
+fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,11 +3,11 @@
 
 npx lint-staged --concurrent false
 
-function changed {
+file_changed() {
   git diff --name-only HEAD@{1} HEAD | grep "^$1" > /dev/null 2>&1
 }
 
-if changed "package.json"; then
+if file_changed "package.json"; then
   echo "Changes detected in package.json, updating package-lock.json in progress."
   npm i --package-lock-only
   git add package-lock.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "abbreve-project",
-  "version": "0.0.0",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "abbreve-project",
-      "version": "0.0.0",
+      "version": "0.3.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.2.0",
         "@fortawesome/free-solid-svg-icons": "^6.2.0",


### PR DESCRIPTION
<!--What issue does this pull request close -->

Closes #112 

### Describe the new changes you added.
- Updated the pre-commit hook in the `.husky/pre-commit` file to do the following:
   1. Check if any changes were detected in `package.json`
   2. If changes were found run `npm i --package-lock-only`to update the `package-lock.json` file to match versioning in `package.json`
   3. Add the updated `package-lock.json` file to the current commit in process.
- Updated `package-lock.json` to include updated versioning for Abbreve project.

### What problem does this fix?
Will ensure first time contributors unfamiliar with dependency management with npm, etc. don't need to worry about whether they need to commit an updated package-lock.json file.

### Share a screenshot of new changes
Output after updating one of the dependency versions in package.json and running the command to commit. 

![Screen Shot 2022-10-11 at 9 06 00 PM](https://user-images.githubusercontent.com/9134674/195232620-950312ba-74c8-4dba-9396-7052084226ac.jpg)
