### PR TITLE
fix: left hero content displacement fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "abbreve-project",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "abbreve-project",
-      "version": "0.17.1",
+      "version": "0.18.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.2.0",
         "@fortawesome/free-solid-svg-icons": "^6.2.0",

--- a/src/components/form.jsx
+++ b/src/components/form.jsx
@@ -83,7 +83,7 @@ const Form = () => {
           </p>
         </div>
 
-        <div className="mt-2 md:mt-0">
+        <div className="mt-2 max-w-[22.5rem] md:mt-0">
           <form className="block md:flex items-center gap-2" id="form">
             <div className="bg-ash h-11 rounded-full flex items-center p-3 dark:shadow-lg">
               <svg


### PR DESCRIPTION
<!--What issue does this pull request close -->

Closes #88

### What new changes did you make? Tick all applicable boxes
- [ ] Added new abbreviation
- [x] Fixed something in the source code
- [ ] Added a new feature
- [ ] Fixed the docs (README.md, CONTRIBTUING.md, etc)

<!--Give a brief outline of changes you made. If you added slang, which ones? -->
### Describe the new changes you added.
Added a max-width utility class to the right hero content's list of classes, so it has a max width of `22.5rem`. This way, it doesn't expand beyond that width when its content changes and, as a result, displace the left content.
<!--Optional, but advised -->
### Share a screenshot of new changes

![Screenshot 2023-01-18 175106](https://user-images.githubusercontent.com/68024640/213246053-b5b0817e-7f88-416b-a78f-69505885617e.png)
![Screenshot 2023-01-18 175142](https://user-images.githubusercontent.com/68024640/213246074-bbe29bc8-563c-4e57-ac22-1ecfd38c8c7e.png)
![Screenshot 2023-01-18 175204](https://user-images.githubusercontent.com/68024640/213246088-1588d08a-061d-4e60-9021-84bf606f0b9f.png)

