### PR TITLE
Update the search button width on small screens

### DIFF
--- a/src/components/form.jsx
+++ b/src/components/form.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { LoadingSpinner } from "./loadingSpinner";
 
 const Form = () => {
@@ -68,7 +68,7 @@ const Form = () => {
   }, [userInput]);
 
   return (
-    <div className="bg-dark py-5 lg:py-12 px-[14px] dark:bg-ash">
+    <div className="bg-dark py-5 mb-12 md:mb-0 lg:py-12 px-[14px] dark:bg-ash">
       <section className="block justify-center md:pb-16 md:flex items-center">
         <div className="md:w-1/2 md:pr-20 md:text-left text-center">
           <h2 className="text-purple font-bold text-xl lg:text-3xl dark:text-deeppurple">

--- a/src/components/form.jsx
+++ b/src/components/form.jsx
@@ -85,7 +85,7 @@ const Form = () => {
 
         <div className="mt-2 md:mt-0">
           <form className="block md:flex items-center gap-2" id="form">
-            <div className="bg-ash h-11 rounded-full flex items-center p-3 dark:shadow-lg">
+            <div className="bg-ash h-11 rounded-full flex items-center p-3 mt-4 md:mt-0 dark:shadow-lg">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
@@ -114,7 +114,7 @@ const Form = () => {
             <button
               onClick={fetchData}
               disabled={isLoading || !hasUserInputChanged}
-              className="bg-deeppurple text-ash font-bold rounded-xl hover:scale-110 p-2 mt-2 md:mt-0">
+              className="bg-deeppurple text-ash font-bold rounded-xl hover:scale-110 p-2 mt-4 md:mt-0 w-full md:w-auto">
               Search
             </button>
           </form>


### PR DESCRIPTION
<!--What issue does this pull request close -->

### What new changes did you make? Tick all applicable boxes
- [ ] Added new abbreviation
- [X] Fixed something in the source code
- [ ] Added a new feature
- [ ] Fixed the docs (README.md, CONTRIBTUING.md, etc)

<!--Give a brief outline of changes you made. If you added slang, which ones? -->
### Describe the new changes you added.
Changed the width of the purple search button on small screens so that it covers the whole screen. This makes it easier to press with one hand and looks better as it isn't left aligned and matches the search bar width

<!--Optional, but advised -->
### Share a screenshot of new changes

Before
![Before](https://user-images.githubusercontent.com/84538727/213805191-86fe8659-0105-4774-bfe4-98b9ae503ec5.png)

After
![iAfter](https://user-images.githubusercontent.com/84538727/213805236-a75e0df3-53a5-42c8-bb89-f4da9dc905bd.png)