### PR TITLE
fix: change placeholder text color

### DIFF
--- a/src/components/form.jsx
+++ b/src/components/form.jsx
@@ -103,7 +103,7 @@ const Form = () => {
               <input
                 type="text"
                 placeholder="Search slang full meaning..."
-                className="flex-1 w-1/2 h-11 rounded-full ml-2 border-none outline-none text-gray text-lg bg-ash"
+                className="flex-1 w-1/2 h-11 rounded-full ml-2 border-none outline-none placeholder:text-gray bg-ash"
                 value={userInput}
                 onChange={(e) =>
                   setUserInput(e.target.value.toLocaleLowerCase())


### PR DESCRIPTION
<!--What issue does this pull request close -->

Closes #220 

### What new changes did you make? Tick all applicable boxes
- [ ] Added new abbreviation
- [X] Fixed something in the source code
- [ ] Added a new feature
- [ ] Fixed the docs (README.md, CONTRIBTUING.md, etc)

<!--Give a brief outline of changes you made. If you added slang, which ones? -->
### Describe the new changes you added.
Changed the input so that placeholder stays its current gray color but input text is black. This changes the caret (cursor) color to black and makes it stand out a bit better

<!--Optional, but advised -->
### Share a screenshot of new changes
