### PR TITLE
Fix: alternatives spelling in IMHO.json

### DIFF
--- a/public/server/db/imho.json
+++ b/public/server/db/imho.json
@@ -1,4 +1,4 @@
 {
   "definition": "In My Honest Opinion",
-  "alternative": "In My Humble Opinion"
+  "alternatives": "In My Humble Opinion"
 }


### PR DESCRIPTION
The alternative for IMHO didn't show up on search as a result to spelling mistake on JSON file.

<!--What issue does this pull request close -->

Closes #

### What new changes did you make? Tick all applicable boxes
- [ ] Added new abbreviation
- [ ] Fixed something in the source code
- [ ] Added a new feature
- [ ] Fixed the docs (README.md, CONTRIBTUING.md, etc)

<!--Give a brief outline of changes you made. If you added slang, which ones? -->
### Describe the new changes you added.

<!--Optional, but advised -->
### Share a screenshot of new changes
