### PR TITLE
open graph image fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta property="og:title" content="Abbreve" />
-    <meta property="og:image" content="https://www.abbreve.tech/src/assets/thumbnail.png" />
-    <meta name="twitter:card" content="https://www.abbreve.tech/src/assets/thumbnail.png" />
+    <meta property="og:image" content="%PUBLIC_URL%/src/assets/thumbnail.png" />
+    <meta name="twitter:card" content="%PUBLIC_URL%/src/assets/thumbnail.png" />
     <meta name="description" content="Open-source dictionary for slang." />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta property="og:title" content="Abbreve" />
-    <meta property="og:image" content="/src/assets/thumbnail.png" />
-    <meta name="twitter:card" content="/src/assets/thumbnail.png" />
+    <meta property="og:image" content="https://www.abbreve.tech/src/assets/thumbnail.png" />
+    <meta name="twitter:card" content="https://www.abbreve.tech/src/assets/thumbnail.png" />
     <meta name="description" content="Open-source dictionary for slang." />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
<!--What issue does this pull request close -->
Below og tag is used for open graph image

<meta property="og:image" content="/src/assets/thumbnail.png" />
And https://www.abbreve.tech/src/assets/thumbnail.png url is loading home page not image.

* https://github.com/Njong392/Abbreve/issues/362
Closes #

### What new changes did you make? Tick all applicable boxes
- [ ] Added new abbreviation
- [x] Fixed something in the source code
- [ ] Added a new feature
- [ ] Fixed the docs (README.md, CONTRIBTUING.md, etc)

<!--Give a brief outline of changes you made. If you added slang, which ones? -->
### Describe the new changes you added.
* using a relative path like /src/assets/thumbnail.png assumes that the image is located at the specified path relative to the current URL
* this approach can lead to incorrect routing and loading of the home page instead of the image

<!--Optional, but advised -->
### Share a screenshot of new changes
