### PR TITLE
added single toggle button

### DIFF
--- a/src/components/navbar.jsx
+++ b/src/components/navbar.jsx
@@ -1,32 +1,39 @@
 import { useEffect } from "react";
 import { useState } from "react";
 import Logo from "../assets/logo.png";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faMoon, faSun } from "@fortawesome/free-solid-svg-icons";
 
 const Navbar = () => {
   const defaultTheme = localStorage.getItem("theme") || "light";
+  const defaultToggle =
+    JSON.parse(localStorage.getItem("toggleButton")) || false;
+
   const [theme, setTheme] = useState(defaultTheme);
+  const [toggleTheme, setToggleTheme] = useState(defaultToggle);
+
   const element = document.documentElement;
 
-  const icons = [
-    {
-      icon: "moon",
-      text: "light",
-    },
-    {
-      icon: "sunny",
-      text: "dark",
-    },
-  ];
+  const handletheme = () => {
+    if (toggleTheme) {
+      setTheme("dark");
+    } else {
+      setTheme("light");
+    }
 
+    setToggleTheme(!toggleTheme);
+  };
   useEffect(() => {
     switch (theme) {
       case "dark":
         element.classList.add("dark");
         localStorage.setItem("theme", "dark");
+        localStorage.setItem("toggleButton", JSON.stringify(false));
         break;
       case "light":
         element.classList.remove("dark");
         localStorage.setItem("theme", "light");
+        localStorage.setItem("toggleButton", JSON.stringify(true));
         break;
       default:
         localStorage.removeItem("theme");
@@ -63,17 +70,13 @@ const Navbar = () => {
             </svg>
           </a>
 
-          {icons?.map((icon) => (
-            <div className="rounded-lg" key={icon.text}>
-              <button
-                onClick={() => setTheme(icon.text)}
-                className={`w-8 h-8 leading-9 text-xl rounded-full m-1 text-ash ${
-                  theme === icon.text && `text-deeppurple`
-                }`}>
-                <ion-icon name={icon.icon}></ion-icon>
-              </button>
-            </div>
-          ))}
+          <div className="rounded-lg">
+            <button
+              onClick={handletheme}
+              className="w-8 h-8 leading-9 text-xl rounded-full m-1 text-deeppurple hover:text-ash hover:scale-110 ">
+              <FontAwesomeIcon icon={toggleTheme ? faMoon : faSun} />
+            </button>
+          </div>
         </div>
       </div>
     </nav>


### PR DESCRIPTION
# BUG: <dark/light mode fix> #239  

### What new changes did you make? Tick all applicable boxes
- [x] Fixed something in the source code


### Before Change
 Prior to the modifications, there were two buttons available for toggling between dark and light mode.

https://github.com/Njong392/Abbreve/assets/64392162/6961da51-5b39-410c-911c-83d95088bd62
 



---

### After Change

  I have implemented a single button that enables the user to switch between dark and light mode. To accomplish this, I incorporated a useState to manage the state and a function to toggle the theme. Additionally, I incorporated a fontAwesome icon that changes dynamically based on the current condition.

https://github.com/Njong392/Abbreve/assets/64392162/5fd1ffc7-0952-4ae9-a340-7e28048a7872




<!--Give a brief outline of changes you made. If you added slang, which ones? -->



