### PR TITLE
fix mode toggles when refreshing the page

### DIFF
--- a/src/components/navbar.jsx
+++ b/src/components/navbar.jsx
@@ -5,23 +5,17 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faMoon, faSun } from "@fortawesome/free-solid-svg-icons";
 
 const Navbar = () => {
-  const deafultTheme = localStorage.getItem("isDarkMode") || false;
-  const [isDarkMode, setIsDarkMode] = useState(deafultTheme);
+  const defaultTheme = localStorage.getItem("isDarkMode") === "true";
+  const [isDarkMode, setIsDarkMode] = useState(defaultTheme);
   const element = document.documentElement;
 
   useEffect(() => {
-    switch (isDarkMode) {
-      case true:
-        element.classList.add("dark");
-        localStorage.setItem("isDarkMode", true);
-        break;
-      case false:
-        element.classList.remove("dark");
-        localStorage.setItem("isDarkMode", false);
-        break;
-      default:
-        localStorage.removeItem("isDarkMode");
-        break;
+    if (isDarkMode) {
+      element.classList.add("dark");
+      localStorage.setItem("isDarkMode", "true");
+    } else {
+      element.classList.remove("dark");
+      localStorage.setItem("isDarkMode", "false");
     }
   }, [isDarkMode]);
 


### PR DESCRIPTION
<!--What issue does this pull request close -->

Closes #

### What new changes did you make? Tick all applicable boxes
- [ ] Added new abbreviation
- [X] Fixed something in the source code
- [ ] Added a new feature
- [ ] Fixed the docs (README.md, CONTRIBTUING.md, etc)

<!--Give a brief outline of changes you made. If you added slang, which ones? -->
### Describe the new changes you added.

I submitted and fixed the issue #395. Now, when we refresh the page, the dark/light mode will not toggle to another. It's only toggled when we click on the toggle button. The issue might because `localStorage.getItem("isDarkMode")` will return string type. So, `defaultTheme` can be `boolean false`, `"false"`, or `"true"`, which may cause the error.

<!--Optional, but advised -->
### Share a screenshot of new changes
The default mode is light:
<img width="500" alt="image" src="https://github.com/Njong392/Abbreve/assets/103609494/36086ecc-5bae-4ff7-b679-87cfe1298c9b">

After we refresh the page, it should be light again:
<img width="500" alt="image" src="https://github.com/Njong392/Abbreve/assets/103609494/9f592687-74b1-4784-872e-8c1c415bafc0">


