### PR TITLE
Fixed: #387 Not showing empty input error message on pressing Search button/

### DIFF
--- a/src/components/form.jsx
+++ b/src/components/form.jsx
@@ -6,7 +6,7 @@ const Form = () => {
   const [error, setError] = useState(false);
   const [errorMessage, setErrorMessage] = useState(false);
   const [userInput, setUserInput] = useState("");
-  const [isUserInputBlank, setIsUserInputBlank] = useState(true);
+  const [isUserInputBlank, setIsUserInputBlank] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const previousUserInput = useRef(undefined);
   const hasUserInputChanged = previousUserInput.current !== userInput;
@@ -63,8 +63,6 @@ const Form = () => {
     if (!isUserInputBlank) {
       previousUserInput.current = userInput;
     }
-
-    clearDataBeforeFetch();
   }, [userInput]);
 
   return (
@@ -107,9 +105,10 @@ const Form = () => {
                 placeholder="Search slang full meaning..."
                 className="flex-1 w-[14rem] h-6 ml-2 border-none outline-none placeholder:text-black bg-ash"
                 value={userInput}
-                onChange={(e) =>
-                  setUserInput(e.target.value.toLocaleLowerCase())
-                }
+                onChange={(e) => {
+                  clearDataBeforeFetch();
+                  setUserInput(e.target.value.toLocaleLowerCase());
+                }}
               />
             </div>
 


### PR DESCRIPTION
- App was not showing "Search bar is Empty..." error message when user perform search on slang which is not present in database and user clear the input box and press Search button.

<!--What issue does this pull request close -->

Closes https://github.com/Njong392/Abbreve/issues/387

### What new changes did you make? Tick all applicable boxes
- [ ] Added new abbreviation
- [x] Fixed something in the source code
- [ ] Added a new feature
- [ ] Fixed the docs (README.md, CONTRIBTUING.md, etc)

<!--Give a brief outline of changes you made. If you added slang, which ones? -->
### Describe the new changes you added.

<!--Optional, but advised -->
### Share a screenshot of new changes
