### PR TITLE
fix-428: The second card is being cut and overflowing on medium and small sized mobile screens

### DIFF
--- a/src/components/hero.jsx
+++ b/src/components/hero.jsx
@@ -122,7 +122,7 @@ const Hero = () => {
       </section>
 
       <section className=" justify-center lg:gap-10 mt-10 items-center flex flex-col lg:flex-row">
-        <div className="border-2 p-4 rounded-lg border-deeppurple  relative md:mt-0 dark:border-purple w-96">
+        <div className="border-2 p-4 rounded-lg border-deeppurple  relative md:mt-0 dark:border-purple lg:w-96">
           <div className="flex gap-2 items-center">
             <img src={emy} alt="" className="h-12 w-12 rounded-full" />
             <div>


### PR DESCRIPTION
<!--What issue does this pull request close -->

Closes https://github.com/Njong392/Abbreve/issues/428

### What new changes did you make? Tick all applicable boxes
- [ ] Added new abbreviation
- [x] Fixed something in the source code
- [ ] Added a new feature
- [ ] Fixed the docs (README.md, CONTRIBTUING.md, etc)

<!--Give a brief outline of changes you made. If you added slang, which ones? -->
### Describe the new changes you added.

<!--Optional, but advised -->
### Share a screenshot of new changes

<img width="516" alt="image" src="https://github.com/Njong392/Abbreve/assets/19145166/d8e36c84-d3c5-4fbf-941f-e5fc7d4d8cef">
<img width="548" alt="image" src="https://github.com/Njong392/Abbreve/assets/19145166/8627048b-f586-48ee-bc18-c35f965dc551">

