### PR TITLE
fix-434 BUG: Abbreviation is not cleared when input is empty after clicking clear button

### DIFF
--- a/src/components/form.jsx
+++ b/src/components/form.jsx
@@ -95,8 +95,9 @@ const Form = () => {
 
   const handleClearInput = useCallback(() => {
     setUserInput("");
+    clearDataBeforeFetch();
     userInputRef.current?.focus();
-  }, []);
+  }, [clearDataBeforeFetch]);
 
   const hadleKeyDownOnClear = useCallback(
     (e) => {


### PR DESCRIPTION
- Removing the abbreviation card, error when user click the clear button.

<!--What issue does this pull request close -->

Closes https://github.com/Njong392/Abbreve/issues/434

### What new changes did you make? Tick all applicable boxes
- [ ] Added new abbreviation
- [x] Fixed something in the source code
- [ ] Added a new feature
- [ ] Fixed the docs (README.md, CONTRIBTUING.md, etc)

<!--Give a brief outline of changes you made. If you added slang, which ones? -->
### Describe the new changes you added.

<!--Optional, but advised -->
### Share a screenshot of new changes
