### PR TITLE
fixed bug to clear abbreviation when input is empty

### DIFF
--- a/src/components/form.jsx
+++ b/src/components/form.jsx
@@ -95,6 +95,7 @@ const Form = () => {
 
   const handleClearInput = useCallback(() => {
     setUserInput("");
+    setData("");
     userInputRef.current?.focus();
   }, []);
 


### PR DESCRIPTION
<!--BUG: Abbreviation is not cleared when input is empty after clicking clear button -->

Closes #434 BUG: Abbreviation is not cleared when input is empty after clicking clear button

### What new changes did you make? Tick all applicable boxes
- [ ] Added new abbreviation
- [x] Fixed something in the source code
- [ ] Added a new feature
- [ ] Fixed the docs (README.md, CONTRIBTUING.md, etc)

<!--Give a brief outline of changes you made. If you added slang, which ones? -->
### initialized setData to empty string on clearing input

<!--Optional, but advised -->
### 
<img width="441" alt="Screenshot 2024-08-13 at 12 00 47 PM" src="https://github.com/user-attachments/assets/6e8971fe-f824-4936-8eb9-5acbfdca5a44">

